### PR TITLE
[BUGFIX] Remove unnecessary character in task item description

### DIFF
--- a/Resources/Private/Templates/ListMenu.html
+++ b/Resources/Private/Templates/ListMenu.html
@@ -51,7 +51,7 @@
                             {item.descriptionHtml -> f:format.raw()}
                         </f:then>
                         <f:else>
-                            <p>b
+                            <p>
                                 {item.description -> f:format.nl2br()}
                             </p>
                         </f:else>


### PR DESCRIPTION
Removes an unintended 'b' character in the paragraph element of the task item description.